### PR TITLE
add functions for including miscellaneous meta data.

### DIFF
--- a/add_meta.py
+++ b/add_meta.py
@@ -1,0 +1,62 @@
+def get_corrections(general_path,identifier):
+    preprintpath = os.path.join(general_path,'outbreak_preprint_matcher/results/update dumps/')
+    litcovidpreprint = os.path.join(preprintpath,'litcovid_update_file.json')
+    pmatch = None
+    if 'pmid' in identifier:
+        with open(litcovidpreprint,'rb') as inputfile:
+            correctionsfile = json.load(inputfile)
+            pmatchlist = [x for x in correctionsfile if x['_id']==identifier]
+            if len(pmatchlist)>0:
+                pmatch = pmatchlist[0]['correction'][0]
+    else:
+        preprintlitcovid = os.path.join(preprintpath,'preprint_update_file.json')
+        with open(preprintlitcovid,'rb') as inputfile:
+            correctionsfile = json.load(inputfile)
+            pmatchlist = [x for x in correctionsfile if x['_id']==identifier]
+            if len(pmatchlist)>0:
+                pmatch = pmatchlist[0]['correction'][0]
+    return(pmatch)
+
+    
+def get_topics(general_path,identifier):
+    tmatch = None
+    topicspath = os.path.join(general_path,'topic_classifier/results/')
+    topicfile = os.path.join(topicspath,'topicCats.json')    
+    with open(topicfile,'rb') as inputfile:
+        topicsfile = json.load(inputfile)
+        tmatchlist = [x for x in topicsfile if x['_id']==identifier]
+        if len(matchlist)>0:
+            rawmatch = tmatchlist[0]['topicCategory']
+            tmatch = rawmatch.strip('[').strip(']').replace("'","").split(',')
+    return(tmatch)
+
+
+def get_altmetrics(general_path,identifier):
+    amatch = None
+    altmetricspath = os.path.join(general_path,'covid_altmetrics/results/')    
+    altmetricsfile = os.path.join(altmetricspath,'altmetric_annotations.json')
+    with open(altmetricsfile,'rb') as inputfile:
+        altfile = json.load(inputfile)
+        amatchlist = [x for x in altfile if x['_id']==identifier]
+        if len(amatchlist)>0:
+            amatch = amatchlist[0]['evaluations']
+    return(amatch)
+
+
+def getAdditionalInfo(doc,general_path):
+    identifier = doc['_id']
+    preprint_corrections = get_corrections(general_path,identifier)
+    if preprint_corrections != None:
+        try:
+            corrlist = doc['correction']
+            corrlist.append(preprint_corrections)
+            doc['correction'] = corrlist
+        except:
+            doc['correction'] = [preprint_corrections]
+    topics = get_topics(general_path,identifier)
+    if topics != None:
+        doc['topicCategory'] = topics
+    evals = get_altmetrics(general_path,identifier)
+    if evals != None:
+        doc['evaluations']=evals
+    return(doc)

--- a/parser.py
+++ b/parser.py
@@ -349,11 +349,8 @@ def parse_corrections(root):
 #@add_addendum
 def load_annotations(data_folder):
     ##general_path should be the directory containing the locally run versions of the preprint matcher, topic classifier and other repos.
-    try:
-        general_path = pathlib.Path(__file__).parents[1].absolute()
-    except:
-        general_path = pathlib.Path(__file__).resolve().parents[1].absolute()
-        
+    general_path = '/opt/home/outbreak'
+    
     res = requests.get('https://www.ncbi.nlm.nih.gov/research/coronavirus-api/export/tsv?')
     litcovid_data = res.text.split('\n')[34:]
 

--- a/parser.py
+++ b/parser.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 
 import requests
 import time
@@ -7,6 +8,7 @@ from xml.etree import ElementTree
 from dateutil import parser
 
 #from outbreak_parser.addendum import add_addendum
+from add_meta import *
 
 from .parser_config import PUBMED_API_KEY
 
@@ -168,6 +170,15 @@ def parseXMLTree(res,pmid):
                     publication["isBasedOn"].append(citObj)
             else:
                 del publication["isBasedOn"]
+ 
+            #Corrections
+            try:
+                corrlist = parse_corrections(root)
+            except:
+                corrlist = []
+            if len(corrlist) > 0:
+                publication['correction'] = corrlist 
+
             #Pub Date
             mm = getattr(root.find('PubmedArticle/MedlineCitation/Article/Journal/JournalIssue/PubDate/Month'), 'text',None)
             yy = getattr(root.find('PubmedArticle/MedlineCitation/Article/Journal/JournalIssue/PubDate/Year'), 'text',None)
@@ -304,9 +315,45 @@ def remove_expired(session):
             # remove ~25% of items between 5 & 9 days old
             keys_to_delete.add(key)
 
+            
+def parse_corrections(root):
+    medline_corrections_dict = {"CommentIn":"comment in",
+                                "CommentOn":"comment on",
+                                "ErratumIn":"erratum in",
+                                "ErratumFor":"erratum for",
+                                "CorrectedAndRepublishedIn":"republished in",
+                                "CorrectedAndRepublishedFrom":"republished from",
+                                "DatasetDescribedIn":"dataset described in",
+                                "DatasetUseReportedIn":"dataset use reported in",
+                                "ExpressionOfConcernIn":"expression of concern in",
+                                "ExpressionOfConcernFor":"expression of concern for",
+                                "RepublishedIn":"republished in",
+                                "RepublishedFrom":"republished from",
+                                "RetractionIn":"retraction in",
+                                "RetractionOf":"retraction of",
+                                "UpdateIn":"update in",
+                                "UpdateOf":"update of"}
+    corrs = root.findall('PubmedArticle/MedlineCitation/CommentsCorrectionsList/CommentsCorrections')
+    corrlist = []
+    for eachcorr in corrs:
+        reftype = eachcorr.get('RefType')
+        refid = eachcorr.find('PMID').text
+        corrdict = {'identifier':'pmid'+refid,
+                    'url':f"https://www.ncbi.nlm.nih.gov/research/coronavirus/publication/{refid}",
+                    'pmid':refid}
+        corrdict['correctionType']=medline_corrections_dict[reftype]
+        corrlist.append(corrdict)
+    return(corrlist)
+
 
 #@add_addendum
 def load_annotations(data_folder):
+    ##general_path should be the directory containing the locally run versions of the preprint matcher, topic classifier and other repos.
+    try:
+        general_path = pathlib.Path(__file__).parents[1].absolute()
+    except:
+        general_path = pathlib.Path(__file__).resolve().parents[1].absolute()
+        
     res = requests.get('https://www.ncbi.nlm.nih.gov/research/coronavirus-api/export/tsv?')
     litcovid_data = res.text.split('\n')[34:]
 
@@ -331,10 +378,12 @@ def load_annotations(data_folder):
 
         try:
             doc = getPubMedDataFor(pmid, session=s)
+            doc = getAdditionalInfo(doc,general_path)
         except requests.exceptions.ConnectionError:
             time.sleep(.5)
             try:
                 doc = getPubMedDataFor(pmid, session=s)
+                doc = getAdditionalInfo(doc,general_path)
             except:
                 given_up_ids.append(pmid)
                 logger.warning(f"Giving up on {pmid}, given up on {len(given_up_ids)} docs")


### PR DESCRIPTION
Added functions for parsing out retractions, errata, etc. from Litcovid.
Added functions for appending preprints, topicCategory and other value-added metadata.
Note that the general_path should be the directory containing the locally run copies of the preprint matcher, topic classifier, etc.